### PR TITLE
Modified TrueHeaders class to order headers

### DIFF
--- a/ooni/tests/test_trueheaders.py
+++ b/ooni/tests/test_trueheaders.py
@@ -36,6 +36,15 @@ class TestTrueHeaders(unittest.TestCase):
         th = TrueHeaders(dummy_headers_dict)
         self.assertEqual(th.getDiff(TrueHeaders(dummy_headers_dict2), ignore=['Header3']), set())
 
-
-
-
+    def test_order_preserved(self):
+        th = TrueHeaders()
+        th.setRawHeaders("HeaderFIRST", ["Value1", "Value2"])
+        th.setRawHeaders("headersecond", ["ValueA", "ValueB"])
+        th.setRawHeaders("HeaderNext", ["ValueZ", "ValueY", "ValueX"])
+        th.setRawHeaders("HeaderLast", ["Value2", "Value1"])
+        self.assertEqual(list(th.getAllRawHeaders()),[
+            ("HeaderFIRST", ["Value1", "Value2"]),
+            ("headersecond", ["ValueA", "ValueB"]),
+            ("HeaderNext", ["ValueZ", "ValueY", "ValueX"]),
+            ("HeaderLast", ["Value2", "Value1"])
+        ])

--- a/ooni/utils/trueheaders.py
+++ b/ooni/utils/trueheaders.py
@@ -34,7 +34,7 @@ class TrueHeaders(http_headers.Headers):
 
     def setRawHeaders(self, name, values):
         #Store original name case for later lookup
-        if name.lower() not in self._caseMappings:
+        if name.lower() not in self._headerCases:
           self._headerCases[name.lower()] = name
         self._rawHeaders[name.lower()] = values
 


### PR DESCRIPTION
Fixes [Issue 254](https://github.com/TheTorProject/ooni-probe/issues/254) by storing TrueHeaders in an `OrderedDict`.

Removes clutter from TrueHeaders class by making `_rawHeaders` a simple `OrderedDict` mapping from header string to list of value strings. This conforms with its type in the superclass (`twisted.web.http_headers.Headers`) and removes the need to override a few methods. A new dict `_headerCases` stores the mapping from lowercase header name to their original capitalization. This is accessed by overriding the superclass method `Headers._canonicalNameCaps`.

Adds `test_trueheaders.test_order_preserved` to ensure `getAllRawHeaders` returns headers in the order they were set.