### PR TITLE
Fix some bugs when invoking and using oonid.

### DIFF
--- a/ooni/api/spec.py
+++ b/ooni/api/spec.py
@@ -82,17 +82,21 @@ class Inputs(ORequestHandler):
         input_file = self.request.files.get("file")[0]
         filename = input_file['filename']
 
-        if not filename or not re.match('(\w.*\.\w.*).*', filename):
-            raise InvalidInputFilename
+        expected_format = "(\w.*\.\w.*).*"
+        if not filename or not re.match(expected_format, filename):
+            raise InvalidInputFilename("File name should match regular "
+                                       "expression: %s" % expected_format)
 
-        if os.path.exists(filename):
-            raise FilenameExists
+        filename = os.path.join(config.inputs_directory, filename)
+        absolute_filename = os.path.abspath(filename)
+
+        if os.path.exists(absolute_filename):
+            raise FilenameExists("File %s already exists." % absolute_filename)
 
         content_type = input_file["content_type"]
         body = input_file["body"]
 
-        fn = os.path.join(config.inputs_directory, filename)
-        with open(os.path.abspath(fn), "w") as fp:
+        with open(absolute_filename, "w") as fp:
             fp.write(body)
 
 class ListTests(ORequestHandler):

--- a/ooni/api/spec.py
+++ b/ooni/api/spec.py
@@ -23,9 +23,14 @@ class FilenameExists(Exception):
 def check_xsrf(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kw):
-        xsrf_header = self.request.headers.get("X-XSRF-TOKEN")
-        if self.xsrf_token != xsrf_header:
+        xsrf_cookie = self.request.headers.get("Cookie")
+        if (not xsrf_cookie) or (not xsrf_cookie.startswith("XSRF-TOKEN=")):
+            raise web.HTTPError(403, "Missing XSRF token.")
+
+        received_token = xsrf_cookie.split("=")[-1]
+        if received_token != self.xsrf_token:
             raise web.HTTPError(403, "Invalid XSRF token.")
+
         return method(self, *args, **kw)
     return wrapper
 

--- a/ooni/api/spec.py
+++ b/ooni/api/spec.py
@@ -174,8 +174,7 @@ class StartTest(ORequestHandler):
         net_test_loader = get_net_test_loader(test_options, test_file)
         try:
             net_test_loader.checkOptions()
-            d = oonidApplication.director.startNetTest(net_test_loader,
-                                                       get_reporters(net_test_loader))
+            d = oonidApplication.director.startNetTest(net_test_loader, None)
             @d.addBoth
             def cleanup(result):
                 for fd, path in tmp_files:

--- a/ooni/director.py
+++ b/ooni/director.py
@@ -129,7 +129,7 @@ class Director(object):
             log.msg("Connecting to Tor Control Port...")
             yield self.getTorState()
 
-        if config.global_options['no-geoip']:
+        if config.global_options.get('no-geoip'):
             aux = [False]
             if config.global_options.get('annotations') is not None:
                 annotations = [k.lower() for k in config.global_options['annotations'].keys()]

--- a/ooni/reporter.py
+++ b/ooni/reporter.py
@@ -171,7 +171,8 @@ class YAMLReporter(OReporter):
 
     """
 
-    def __init__(self, test_details, report_destination='.',
+    def __init__(self, test_details,
+                 report_destination=config.reports_directory,
                  report_filename=None):
         self.reportDestination = report_destination
 

--- a/ooni/tests/test_nettest.py
+++ b/ooni/tests/test_nettest.py
@@ -122,7 +122,7 @@ class TestNetTest(unittest.TestCase):
     def tearDown(self):
         os.remove(dummyInputFile)
         if self.filename != "":
-            os.remove(self.filename)
+            os.remove(os.path.join(config.reports_directory, self.filename))
 
     def assertCallable(self, thing):
         self.assertIn('__call__', dir(thing))
@@ -297,7 +297,7 @@ class TestNettestTimeout(ConfigTestCase):
         super(TestNettestTimeout, self).tearDown()
         self.factory.stopFactory()
         self.port.stopListening()
-        os.remove(self.filename)
+        os.remove(os.path.join(config.reports_directory, self.filename))
 
     def test_nettest_timeout(self):
         ntl = NetTestLoader(('-u', 'http://localhost:8007/'))

--- a/ooni/tests/test_oonicli.py
+++ b/ooni/tests/test_oonicli.py
@@ -48,11 +48,11 @@ class TestRunDirector(ConfigTestCase):
     @defer.inlineCallbacks
     def run_helper(self, test_name, args, verify_function):
         output_file = 'test_report.yaml'
-        self.filenames.append(output_file)
+        self.filenames.append(os.path.join(config.reports_directory, output_file))
         sys.argv = ['', '-n', '-o', output_file, test_name]
         sys.argv.extend(args)
         yield runWithDirector(False, False)
-        with open(output_file) as f:
+        with open(os.path.join(config.reports_directory, output_file)) as f:
             entries = yaml.safe_load_all(f)
             header = entries.next()
             try:

--- a/ooni/utils/txscapy.py
+++ b/ooni/utils/txscapy.py
@@ -125,9 +125,9 @@ def getDefaultIface():
     # Workaround: Set the default interface in ooniprobe.conf
     networks = getNetworksFromRoutes()
     for net in networks:
-        if net.is_private:
+        if net.netmask == ipaddr.IPv4Address("0.0.0.0"):
             return net.iface
-    raise IfaceError
+    raise IfaceError("Could not auto-detect default interface.")
 
 def hasRawSocketPermission():
     try:


### PR DESCRIPTION
- `config.global_options['no-geoip']` failed because of non-existing key.
- The second argument passed to `startNetTest()` was no string.
- `__init__()` in `YAMLReporter` used the current directory instead of the report directory.