### PR TITLE
13581: Avoid hacking sys.path in bin/* scripts as that is a security risk.

### DIFF
--- a/bin/oonideckgen
+++ b/bin/oonideckgen
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
-import os
-import sys
 import exceptions
-
-sys.path[:] = map(os.path.abspath, sys.path)
-sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 from twisted.internet import defer, reactor
 

--- a/bin/ooniprobe
+++ b/bin/ooniprobe
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
-import os, sys
 import copy_reg
 from twisted.internet import reactor
-
-# Hack to set the proper sys.path. Overcomes the export PYTHONPATH pain.
-sys.path[:] = map(os.path.abspath, sys.path)
-sys.path.insert(0, os.path.abspath(os.getcwd()))
 
 # This is a hack to overcome a bug in python
 from ooni.utils.hacks import patched_reduce_ex

--- a/bin/oonireport
+++ b/bin/oonireport
@@ -1,10 +1,4 @@
 #!/usr/bin/env python
-import os
-import sys
-
-sys.path[:] = map(os.path.abspath, sys.path)
-sys.path.insert(0, os.path.abspath(os.getcwd()))
-
 from twisted.internet import defer, reactor
 
 from ooni.utils import log

--- a/bin/ooniresources
+++ b/bin/ooniresources
@@ -1,10 +1,4 @@
 #!/usr/bin/env python
-import os
-import sys
-
-sys.path[:] = map(os.path.abspath, sys.path)
-sys.path.insert(0, os.path.abspath(os.getcwd()))
-
 from twisted.internet import defer, reactor
 
 from ooni.utils import log

--- a/data/inputs/README
+++ b/data/inputs/README
@@ -3,38 +3,38 @@ the correct functionality of the various OONIProbe tests.
 
 # DNS Consistency
 
-./bin/ooniprobe -o dns_tamper_test.yamloo data/nettests/blocking/dns_consistency.py -t
+./ooniprobe-dev -o dns_tamper_test.yamloo data/nettests/blocking/dns_consistency.py -t
 example_inputs/dns_tamper_test_resolvers.txt -f example_inputs/dns_tamper_file.txt
 
 less dns_tamper_test.yamloo
 
 # Captive Portal
 
-./bin/ooniprobe -o captive_portal_test.yamloo data/nettests/core/captiveportal.py
+./ooniprobe-dev -o captive_portal_test.yamloo data/nettests/core/captiveportal.py
 
 less captive_portal_test.yamloo
 
 # HTTP Host
 
-./bin/ooniprobe -o http_host.yamloo data/nettests/manipulation/http_host.py -b http://ooni.nu/test -f example_inputs/http_host_file.txt
+./ooniprobe-dev -o http_host.yamloo data/nettests/manipulation/http_host.py -b http://ooni.nu/test -f example_inputs/http_host_file.txt
 
 less http_host.yamloo
 
 # Keyword filtering
 
-./bin/ooniprobe -o keyword_filtering.yamloo data/nettests/core/keyword_filtering.py -b http://ooni.nu/test/ -f test_inputs/keyword_filtering_file.txt
+./ooniprobe-dev -o keyword_filtering.yamloo data/nettests/core/keyword_filtering.py -b http://ooni.nu/test/ -f test_inputs/keyword_filtering_file.txt
 
 less keyword_filtering.yamloo
 
 # URL List
 
-./bin/ooniprobe -o url_lists.yamloo data/nettests/core/url_list.py -f test_inputs/url_lists_file.txt
+./ooniprobe-dev -o url_lists.yamloo data/nettests/core/url_list.py -f test_inputs/url_lists_file.txt
 
 less url_lists.yamloo
 
 # Squid transparent proxy
 
-./bin/ooniprobe -o squid.yamloo data/nettests/core/squid.py
+./ooniprobe-dev -o squid.yamloo data/nettests/core/squid.py
 
 less squid.yamloo
 

--- a/docs/source/tests/dnsspoof.rst
+++ b/docs/source/tests/dnsspoof.rst
@@ -21,7 +21,7 @@ This test performs A queries to a test resolver and a known good control resolve
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/manipulation/dns_spoof.py [-s] [-k] [-i] -r <test resolver> -h <hostname> -b IP:PORT`
+`ooniprobe nettests/manipulation/dns_spoof.py [-s] [-k] [-i] -r <test resolver> -h <hostname> -b IP:PORT`
 
 *test resolver* is a single test resolver (IP address).
 *hostname* is the hostname to query.
@@ -35,7 +35,7 @@ Sample report
 =============
 
 From running:
-`./bin/ooniprobe nettests/manipulation/dns_spoof.py -h torproject.org -r 4.2.2.2:53`
+`ooniprobe nettests/manipulation/dns_spoof.py -h torproject.org -r 4.2.2.2:53`
 
 ::
 

--- a/docs/source/tests/http_header_field_manipulation.rst
+++ b/docs/source/tests/http_header_field_manipulation.rst
@@ -23,14 +23,14 @@ detected tampering.
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/manipulation/http_header_field_manipulation.py -b <address of backend> [-h <headers>]`
+`ooniprobe nettests/manipulation/http_header_field_manipulation.py -b <address of backend> [-h <headers>]`
 `address of backend` is the IP:PORT of the SimpleHTTPChannel backend.
 
 Sample report
 =============
 
 From running:
-`./bin/ooniprobe nettests/manipulation/http_header_field_manipulation.py`
+`ooniprobe nettests/manipulation/http_header_field_manipulation.py`
 If no backend is specified, the default backend is 127.0.0.1:57001, where you will need to have oonib listening.
 
 ::

--- a/docs/source/tests/http_host.rst
+++ b/docs/source/tests/http_host.rst
@@ -39,7 +39,7 @@ test.
 How to run the test
 ===================
 
-`./bin/ooniprobe nettest/core/http_host.py -f <input file> -b <backend url> -c <content>`
+`ooniprobe nettest/core/http_host.py -f <input file> -b <backend url> -c <content>`
 
 *input_file* is a file containing the hostnames to check for censorship one per line.
 
@@ -55,7 +55,7 @@ Sample report
 =============
 
 From running:
-`./bin/ooniprobe nettests/core/http_host.py`
+`ooniprobe nettests/core/http_host.py`
 
 ::
 

--- a/docs/source/tests/http_invalid_request_line.rst
+++ b/docs/source/tests/http_invalid_request_line.rst
@@ -81,7 +81,7 @@ is usually being split on the `.`.
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/manipulation/http_invalid_request_line.py -b <address of backend>`
+`ooniprobe nettests/manipulation/http_invalid_request_line.py -b <address of backend>`
 
 *address of the backend* is the hostname or IP address of a backend that runs
 a TCP echo server on port 80.
@@ -91,7 +91,7 @@ Sample report
 
 From running:
 
-`./bin/ooniprobe nettests/manipulation/http_invalid_request_line.py -b 127.0.0.1 -p 57002`
+`ooniprobe nettests/manipulation/http_invalid_request_line.py -b 127.0.0.1 -p 57002`
 
 ::
 

--- a/docs/source/tests/tcpconnect.rst
+++ b/docs/source/tests/tcpconnect.rst
@@ -28,7 +28,7 @@ If the connection succeeds the test will report "success".
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/core/tcpconnect.py -f <input file>`
+`ooniprobe nettests/core/tcpconnect.py -f <input file>`
 
 *input file* a list of IP:PORT pairs to perform TCP connections to.
 
@@ -36,7 +36,7 @@ Sample report
 =============
 
 From running:
-`./bin/ooniprobe nettests/core/tcpconnect.py -f <input file>`
+`ooniprobe nettests/core/tcpconnect.py -f <input file>`
 
 ::
 

--- a/docs/source/tests/template.rst
+++ b/docs/source/tests/template.rst
@@ -20,13 +20,13 @@ Description
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/core/my_test_name.py`
+`ooniprobe nettests/core/my_test_name.py`
 
 Sample report
 =============
 
 From running:
-`./bin/ooniprobe nettests/core/my_test_name.py`
+`ooniprobe nettests/core/my_test_name.py`
 
 ::
 

--- a/docs/source/tests/traceroute.rst
+++ b/docs/source/tests/traceroute.rst
@@ -47,7 +47,7 @@ received a TTL expired from a router in a certain network range.
 How to run the test
 ===================
 
-`./bin/ooniprobe nettests/manipulation/traceroute.py -b <backend ip>``
+`ooniprobe nettests/manipulation/traceroute.py -b <backend ip>``
 
 *backend ip* is the IP address of the backend to traceroute to
 
@@ -56,7 +56,7 @@ Sample report
 
 From running:
 
-`./bin/ooniprobe nettests/core/traceroute.py -b 8.8.8.8`
+`ooniprobe nettests/core/traceroute.py -b 8.8.8.8`
 
 ::
 

--- a/ooni/nettests/experimental/chinatrigger.py
+++ b/ooni/nettests/experimental/chinatrigger.py
@@ -17,7 +17,7 @@ class ChinaTriggerTest(BaseScapyTest):
     by Philipp Winter to engage chinese probes in active scanning.
 
     Example of running it:
-    ./bin/ooniprobe chinatrigger -d 127.0.0.1 -p 8080
+    ooniprobe chinatrigger -d 127.0.0.1 -p 8080
     """
 
     name = "chinatrigger"

--- a/ooniprobe-dev
+++ b/ooniprobe-dev
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Developer script for running ooniprobe directly from the repository.
+# We don't automatically add "$PWD" to PYTHONPATH as that is a security risk
+# when run as /usr/bin/ooniprobe on an end user's computer.
+cd "$(realpath "$(dirname "$0")")"
+PYTHONPATH="$PWD" exec ./bin/ooniprobe

--- a/scripts/before_i_commit.sh
+++ b/scripts/before_i_commit.sh
@@ -28,7 +28,7 @@ else
   echo "Assuming that your virtual environment is pre-configured...";
 fi
 
-./bin/ooniprobe -i decks/before_i_commit.testdeck
+./ooniprobe-dev -i decks/before_i_commit.testdeck
 
 echo "Below you should not see anything"
 echo "---------------------------------"


### PR DESCRIPTION
We want to run these scripts with extra capabilities, using setcap. However, if
the end user can set PYTHONPATH, then they can feed arbitrary code into these
scripts and give extra capabilities to that code, which we should not allow.

Includes a ooniprobe-dev wrapper shell script to make things easier for
developers running directly from the repository. The important thing is that
this script is developer-only and *not* installed on end users' machines.