### PR TITLE
Feature/unique identifier + Test helper addresses

### DIFF
--- a/data/ooniprobe.conf.sample
+++ b/data/ooniprobe.conf.sample
@@ -17,6 +17,8 @@ privacy:
     # Should we collect a full packet capture on the client?
     includepcap: false
 reports:
+    # Should we place a unique ID inside of every report
+    unique_id: true
     # This is a prefix for each packet capture file (.pcap) per test:
     pcap: null
     collector: null

--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -224,6 +224,7 @@ class Deck(InputFile):
             for th in net_test_loader.requiredTestHelpers:
                 if not th['test_class'].localOptions[th['option']]:
                     th['test_class'].localOptions[th['option']] = test_helpers[th['name']].encode('utf-8')
+                net_test_loader.testHelpers[th['option']] = th['test_class'].localOptions[th['option']]
 
             if not net_test_loader.collector:
                 net_test_loader.collector = collector.encode('utf-8')

--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -37,7 +37,8 @@ class InputFile(object):
             try:
                 self.verify()
             except AssertionError:
-                log.err("The input %s failed validation. Going to consider it not cached." % self.id)
+                log.err("The input %s failed validation."
+                        "Going to consider it not cached." % self.id)
                 return False
             return True
         return False
@@ -45,13 +46,13 @@ class InputFile(object):
     def save(self):
         with open(self.cached_descriptor, 'w+') as f:
             json.dump({
-                          'name': self.name,
-                          'id': self.id,
-                          'version': self.version,
-                          'author': self.author,
-                          'date': self.date,
-                          'description': self.description
-                      }, f)
+                'name': self.name,
+                'id': self.id,
+                'version': self.version,
+                'author': self.author,
+                'date': self.date,
+                'description': self.description
+            }, f)
 
     def load(self, descriptor):
         self.name = descriptor['name']
@@ -107,7 +108,8 @@ class Deck(InputFile):
         self.decksDirectory = os.path.abspath(decks_directory)
         self.deckHash = deck_hash
 
-        if deckFile: self.loadDeck(deckFile)
+        if deckFile:
+            self.loadDeck(deckFile)
 
     @property
     def cached_file(self):

--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -215,7 +215,8 @@ class NetTestLoader(object):
             'software_version': software_version,
             'options': options,
             'input_hashes': input_file_hashes,
-            'report_id': self.reportID
+            'report_id': self.reportID,
+            'test_helpers': self.testHelpers
         }
         return test_details
 
@@ -323,6 +324,7 @@ class NetTestLoader(object):
         self.testName = test_class_name_to_name(test_class.name)
         self.testCases = test_cases
         self.testClasses = set([])
+        self.testHelpers = {}
 
         if config.reports.unique_id is True:
             self.reportID = randomStr(64)

--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -10,7 +10,7 @@ from twisted.python import usage, reflect
 
 from ooni import otime
 from ooni.tasks import Measurement
-from ooni.utils import log, sanitize_options
+from ooni.utils import log, sanitize_options, randomStr
 from ooni.utils.net import hasRawSocketPermission
 from ooni.settings import config
 
@@ -203,18 +203,20 @@ class NetTestLoader(object):
             input_file_hashes.append(input_file['hash'])
 
         options = sanitize_options(self.options)
-        test_details = {'start_time': otime.epochToUTC(time.time()),
-                        'probe_asn': config.probe_ip.geodata['asn'],
-                        'probe_cc': config.probe_ip.geodata['countrycode'],
-                        'probe_ip': config.probe_ip.geodata['ip'],
-                        'probe_city': config.probe_ip.geodata['city'],
-                        'test_name': self.testName,
-                        'test_version': self.testVersion,
-                        'software_name': 'ooniprobe',
-                        'software_version': software_version,
-                        'options': options,
-                        'input_hashes': input_file_hashes
-                        }
+        test_details = {
+            'start_time': otime.epochToUTC(time.time()),
+            'probe_asn': config.probe_ip.geodata['asn'],
+            'probe_cc': config.probe_ip.geodata['countrycode'],
+            'probe_ip': config.probe_ip.geodata['ip'],
+            'probe_city': config.probe_ip.geodata['city'],
+            'test_name': self.testName,
+            'test_version': self.testVersion,
+            'software_name': 'ooniprobe',
+            'software_version': software_version,
+            'options': options,
+            'input_hashes': input_file_hashes,
+            'report_id': self.reportID
+        }
         return test_details
 
     def _parseNetTestOptions(self, klass):
@@ -321,6 +323,10 @@ class NetTestLoader(object):
         self.testName = test_class_name_to_name(test_class.name)
         self.testCases = test_cases
         self.testClasses = set([])
+
+        if config.reports.unique_id is True:
+            self.reportID = randomStr(64)
+
         for test_class, test_method in self.testCases:
             self.testClasses.add(test_class)
 
@@ -341,7 +347,7 @@ class NetTestLoader(object):
 
             test_instance = klass()
             if test_instance.requiresRoot and not hasRawSocketPermission():
-                raise errors.InsufficientPrivileges
+                raise e.InsufficientPrivileges
             if test_instance.requiresTor:
                 self.requiresTor = True
             test_instance.requirements()
@@ -446,13 +452,14 @@ class NetTest(object):
         return ' '.join(tc.name for tc, _ in self.testCases)
 
     def doneNetTest(self, result):
-        if not self.summary:
-            return
-        print "Summary for %s" % self.testDetails['test_name']
-        print "------------" + "-"*len(self.testDetails['test_name'])
-        for test_class in self.testClasses:
-            test_instance = test_class()
-            test_instance.displaySummary(self.summary)
+        if self.summary:
+            print "Summary for %s" % self.testDetails['test_name']
+            print "------------" + "-"*len(self.testDetails['test_name'])
+            for test_class in self.testClasses:
+                test_instance = test_class()
+                test_instance.displaySummary(self.summary)
+        if self.testDetails["report_id"]:
+            print "Report ID: %s" % self.testDetails["report_id"]
 
     def doneReport(self, report_results):
         """


### PR DESCRIPTION
In here I add 2 new keys to the report data format.

The report_id that is a random 64 character value set by the client.

The test_helpers that contains the addresses of the test helpers used.

I will now issue a PR on ooni-spec to include these changes.