### PR TITLE
Don't mention the default bouncer twice.

### DIFF
--- a/ooni/oonicli.py
+++ b/ooni/oonicli.py
@@ -41,7 +41,7 @@ class Options(usage.Options):
         ["collector", "c", None,
          "Address of the collector of test results. This option should not be used, but you should always use a bouncer."],
         ["bouncer", "b", 'httpo://nkvphnp3p6agi5qq.onion',
-         "Address of the bouncer for test helpers. default: httpo://nkvphnp3p6agi5qq.onion"],
+         "Address of the bouncer for test helpers."],
         ["logfile", "l", None, "log file name"],
         ["pcapfile", "O", None, "pcap file name"],
         ["configfile", "f", None,


### PR DESCRIPTION
When you run ```ooniprobe``` with no arguments, this is the help message you would get:

```
$ ooniprobe
WARNING: running ooniprobe involves some risk that varies greatly
         from country to country. You should be aware of this when
         running the tool. Read more about this in the manpage or README.
Options:
  -h, --help          Display this help and exit.
  -r, --resume        
  -n, --no-collector  
  -g, --no-geoip      
  -s, --list          
  -p, --printdeck     
  -v, --verbose       
  -o, --reportfile=   report file name
  -i, --testdeck=     Specify as input a test deck: a yaml file containing the
                      tests to run and their arguments
  -c, --collector=    Address of the collector of test results. This option
                      should not be used, but you should always use a bouncer.
  -b, --bouncer=      Address of the bouncer for test helpers. default:
                      httpo://nkvphnp3p6agi5qq.onion [default:
                      httpo://nkvphnp3p6agi5qq.onion]
  -l, --logfile=      log file name
  -O, --pcapfile=     pcap file name
  -f, --configfile=   Specify a path to the ooniprobe configuration file
  -d, --datadir=      Specify a path to the ooniprobe data directory
  -a, --annotations=  Annotate the report with a key:value[, key:value] format.
      --spew          Print an insanely verbose log of everything that happens.
                      Useful         when debugging freezes or locks in complex
                      code.
      --version       Display the ooniprobe version and exit.

ooniprobe loads and executes a suite or a set of suites of network tests. These
are loaded from modules, packages and files listed on the command line

/home/d/virtualenv/bin/ooniprobe: No test filename specified!
```

Note that in ```--bouncer```, the default .onion address is mentioned twice. This pull request should fix it.