### PR TITLE
Bug: add notes to uninstall/downgrade Twisted via pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,12 @@ On unix systems::
 
     sudo pip install ooniprobe
 
+**BUG** Note: Twisted version needs to be >=12.2.0 and <=14.0.0
+unistall/downgrage Twisted::
+
+    sudo pip uninstall Twisted
+    sudo pip install 'Twisted>=12.2.0,<=14.0.0'
+
 To install it from the current master run::
 
     sudo pip install https://github.com/TheTorProject/ooni-probe/archive/master.zip


### PR DESCRIPTION
pypi ooniprobe requirements installs the latest version of Twisted Currently
due to a bug in Twisted ooniprobe requires with Twisted versions >=12.2.0 and
<=14.0.0