### PR TITLE
Improve ./bin/ooniprobe-dev

### DIFF
--- a/bin/ooniprobe-dev
+++ b/bin/ooniprobe-dev
@@ -2,5 +2,9 @@
 # Developer script for running ooniprobe directly from the repository.
 # We don't automatically add "$PWD" to PYTHONPATH as that is a security risk
 # when run as /usr/bin/ooniprobe on an end user's computer.
-cd "$(realpath "$(dirname "$0")")/.."
-PYTHONPATH="$PWD" exec ./bin/ooniprobe $@
+ROOTDIR=$(cd $(dirname $(dirname $0)) && pwd -P)
+if [ $? -ne 0 ]; then
+    echo "$0: cannot determine toplevel directory" 1>&2
+    exit 1
+fi
+PYTHONPATH="$ROOTDIR" exec ./bin/ooniprobe "$@"

--- a/bin/ooniprobe-dev
+++ b/bin/ooniprobe-dev
@@ -7,4 +7,4 @@ if [ $? -ne 0 ]; then
     echo "$0: cannot determine toplevel directory" 1>&2
     exit 1
 fi
-PYTHONPATH="$ROOTDIR" exec ./bin/ooniprobe "$@"
+PYTHONPATH="$ROOTDIR" exec $ROOTDIR/bin/ooniprobe "$@"


### PR DESCRIPTION
- make sure it also works on MacOSX where `realpath` is not available

- make sure it bails out with an explicit error message if finding out the toplevel directory path is not possible

- make sure arguments are correctly forwarded to `./bin/ooniprobe` [edit: this was already in #412, I just added quotes around $@ since this appears to be even more correct]

Fixes `./bin/ooniprobe-dev -s` on my system.

Spotted while performing the review of #410.