### PR TITLE
Remove obsolete install method on Debian/Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,15 +47,6 @@ probe is a liability for you, please be aware of this risk.
 OONI in 5 minutes
 =================
 
-On debian testing or unstable::
-
-    sudo apt-get install ooniprobe
-
-If you are running debian stable you can get it from backports via::
-
-    sudo sh -c 'echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list'
-    sudo apt-get update && sudo apt-get install ooniprobe
-
 On unix systems::
 
     sudo pip install ooniprobe
@@ -93,29 +84,6 @@ Run this command to automatically update your crontab::
 
 Installation
 ============
-
-Debian based systems
---------------------
-
-If you are running Debian testing or Debian unstable you can install ooniprobe
-simply with::
-    
-    apt-get install ooniprobe
-
-If you are running Debian stable you can get it from backports via::
-
-    sudo sh -c 'echo "deb http://http.debian.net/debian wheezy-backports main" >> /etc/apt/sources.list'
-    sudo apt-get update && sudo apt-get install ooniprobe
-
-If you are running Ubuntu 14.04 LTS, 14.10 or 15.04 you can install it from the PPA
-(https://launchpad.net/~irl/+archive/ubuntu/ooni/)::
-
-    sudo add-apt-repository ppa:irl/ooni
-    sudo apt-get update && sudo apt-get install ooniprobe
-
-You will be warned that the packages are unauthenticated. This is due to the
-PPA not being signed and is normal behaviour. If you would prefer to verify the
-integrity of the package, use our private Debian repository below.
 
 Mac OS X
 --------


### PR DESCRIPTION
Currently the ooniprobe packages offered in Debian and Ubuntu are old,
unavailable in some releases or very old version. Removing obsolete
install instructions until the ooniprobe packages in the repositories
are available and up-to-date