### PR TITLE
Drop dependencies that are for sub-modules of ooni

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,8 @@ pyOpenSSL>=0.13
 geoip
 txtorcon>=0.7
 txsocksx>=0.0.2
-parsley>=1.1
 scapy-real>=2.2.0-dev
 pypcap>=1.1
 service-identity
 pydumbnet
-pyasn1
-pyasn1-modules
-characteristic
 zope.interface
-cryptography


### PR DESCRIPTION
In this branch we should be cleaning up our dependency list and adding a build matrix to test for successful installation on the various versions of OSs supported by travis.

This should fix #469