### PR TITLE
Hotfix: downgrage pypcap 1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ txtorcon>=0.7
 txsocksx>=0.0.2
 parsley>=1.1
 scapy-real>=2.2.0-dev
-pypcap>=1.1
+pypcap<1.4
 service-identity
 pydumbnet
 pyasn1


### PR DESCRIPTION
Pypcap version 1.1.4 breaks some scapy based tests.
(https://github.com/TheTorProject/ooni-probe/issues/472)
This is a hotfix to downgrade or install pypcap version < 1.1.4