### PR TITLE
The version number in master should always be greater than the latest…

### DIFF
--- a/ooni/__init__.py
+++ b/ooni/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 __author__ = "Open Observatory of Network Interference"
-__version__ = "1.4.2"
+__version__ = "1.5.0-master"
 
 __all__ = ['config', 'inputunit', 'kit',
            'lib', 'nettest', 'oonicli', 'report', 'reporter',

--- a/ooni/__init__.py
+++ b/ooni/__init__.py
@@ -2,6 +2,9 @@
 
 __author__ = "Open Observatory of Network Interference"
 __version__ = "1.5.0-master"
+# This is the version number of resources to be downloaded
+# when a release is made it should be aligned to __version__
+__resources_version__ = "1.4.2"
 
 __all__ = ['config', 'inputunit', 'kit',
            'lib', 'nettest', 'oonicli', 'report', 'reporter',

--- a/ooni/resources/__init__.py
+++ b/ooni/resources/__init__.py
@@ -1,6 +1,7 @@
-from ooni import __version__ as ooniprobe_version
+from ooni import __resources_version__ as resources_version
 
 __version__ = "0.2.0"
 
 ooni_resources_url = ("https://github.com/TheTorProject/ooni-probe/releases"
-                      "/download/v{}/ooni-resources.tar.gz").format(ooniprobe_version)
+                      "/download/v{}/"
+                      "ooni-resources.tar.gz").format(resources_version)


### PR DESCRIPTION
… release

This is to allow us to distinguish reports that are run from ooniprobe versions
cloned from master and those run from packages.