### PR TITLE
Increase the default timeout for the vanilla tor test to 300 seconds

### DIFF
--- a/ooni/nettests/blocking/vanilla_tor.py
+++ b/ooni/nettests/blocking/vanilla_tor.py
@@ -18,7 +18,7 @@ class TorIsNotInstalled(Exception):
 
 class UsageOptions(usage.Options):
     optParameters = [
-        ['timeout', 't', 200,
+        ['timeout', 't', 300,
          'Specify the timeout after which to consider '
          'the Tor bootstrapping process to have failed.'], ]
 


### PR DESCRIPTION
This closes #508