### PR TITLE
Make inputs shared across all NetTestCase measurements

### DIFF
--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -585,10 +585,13 @@ class NetTest(object):
         """
 
         for test_class, test_methods in self.testCases:
-            # load the input processor as late as possible
-            for input in test_class.inputs:
+            # load a singular input processor for all instances
+            all_inputs = test_class.inputs
+            for test_input in all_inputs:
                 measurements = []
                 test_instance = test_class()
+                # Set each instances inputs to a singular input processor
+                test_instance.inputs = all_inputs
                 test_instance._setUp()
                 test_instance.summary = self.summary
                 for method in test_methods:
@@ -596,7 +599,7 @@ class NetTest(object):
                     measurement = self.makeMeasurement(
                         test_instance,
                         method,
-                        input)
+                        test_input)
                     measurements.append(measurement.done)
                     self.state.taskCreated()
                     yield measurement
@@ -721,7 +724,6 @@ class NetTestCase(object):
         It gets called once for every input.
         """
         self.report = {}
-        self.inputs = None
 
     def requirements(self):
         """


### PR DESCRIPTION
This pull request makes the inputs iterator shared by all the measurement tests within a NetTestCase. Per issue #503 , In order to make bisection style testing functional the individual tests need to be able to pass data to the main test_case.inputs generator that seeds each measurement.  This provides opportunities for each measurement test in a NetTestCase to communicate with the iterator to do things such as adding additional values to be passed to measurement tests as a later input.

In the files changed you will find the very-small code update required for this feature, unit-tests that ensure proper functionality, and updates to the user documentation to guide others in effectively taking advantage of it.