### PR TITLE
Add support for specifying the test name without the category prefix.

### DIFF
--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -73,6 +73,9 @@ def nettest_to_path(path, allow_arbitrary_paths=False):
     """
     Takes as input either a path or a nettest name.
 
+    The nettest name may either be prefixed by the category of the nettest (
+    blocking, experimental, manipulation or third_party) or not.
+
     Args:
 
         allow_arbitrary_paths:
@@ -85,11 +88,30 @@ def nettest_to_path(path, allow_arbitrary_paths=False):
     if allow_arbitrary_paths and os.path.exists(path):
         return path
 
-    fp = FilePath(config.nettest_directory).preauthChild(path + '.py')
-    if fp.exists():
-        return fp.path
-    else:
+    p = path.split("/")
+    test_name = p[0]
+    if len(p) > 1:
+        test_categories = [p[0]]
+        test_name = p[1]
+
+    test_categories = [
+        "blocking",
+        "experimental",
+        "manipulation",
+        "third_party"
+    ]
+    nettest_dir = FilePath(config.nettest_directory)
+    found_path = None
+    for category in test_categories:
+        p = nettest_dir.preauthChild(os.path.join(category, test_name) + '.py')
+        if p.exists():
+            if found_path is not None:
+                raise Exception("Found two tests named %s" % test_name)
+            found_path = p.path
+
+    if not found_path:
         raise e.NetTestNotFound(path)
+    return found_path
 
 
 class Deck(InputFile):

--- a/ooni/deck.py
+++ b/ooni/deck.py
@@ -88,12 +88,7 @@ def nettest_to_path(path, allow_arbitrary_paths=False):
     if allow_arbitrary_paths and os.path.exists(path):
         return path
 
-    p = path.split("/")
-    test_name = p[0]
-    if len(p) > 1:
-        test_categories = [p[0]]
-        test_name = p[1]
-
+    test_name = path.rsplit("/", 1)[-1]
     test_categories = [
         "blocking",
         "experimental",

--- a/ooni/tests/test_deck.py
+++ b/ooni/tests/test_deck.py
@@ -4,7 +4,8 @@ from twisted.internet import defer
 from twisted.trial import unittest
 
 from hashlib import sha256
-from ooni.deck import InputFile, Deck
+from ooni import errors
+from ooni.deck import InputFile, Deck, nettest_to_path
 from ooni.tests.mocks import MockBouncerClient, MockCollectorClient
 
 net_test_string = """
@@ -183,3 +184,11 @@ class TestDeck(BaseTestCase):
             deck.netTestLoaders[1].localOptions['backend'],
             '2.2.2.2'
         )
+
+    def test_nettest_to_path(self):
+        path_a = nettest_to_path("blocking/http_requests")
+        path_b = nettest_to_path("http_requests")
+        self.assertEqual(path_a, path_b)
+        self.assertRaises(errors.NetTestNotFound,
+                          nettest_to_path,
+                          "invalid_test")


### PR DESCRIPTION
This implements: https://github.com/TheTorProject/ooni-probe/issues/483