### PR TITLE
Adds Debian stable backports installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,12 @@ On Debian testing or unstable::
 
     sudo apt-get install ooniprobe
 
+On Debian stable (jessie)::
+
+    echo 'deb http://ftp.debian.org/debian jessie-backports main' | sudo tee -a /etc/apt/sources.list
+    sudo apt-get update
+    sudo apt-get install ooniprobe
+
 On Ubuntu 16.04 (xenial), 15.10 (wily) or 14.04 (trusty)::
 
     sudo add-apt-repository ppa:irl/ooni


### PR DESCRIPTION
Around 9pm this evening, ooniprobe_1.4.2-1~bpo8+1_amd64.changes was ACCEPTED into jessie-backports, jessie-backports.

It looks that 1.5.1 can be backported from tomorrow, as it is scheduled to enter testing then.