### PR TITLE
Make sure oonireport receives correct args

### DIFF
--- a/ooni/report/cli.py
+++ b/ooni/report/cli.py
@@ -60,7 +60,7 @@ def tor_check():
         sys.exit(1)
 
 
-def run(args=sys.argv):
+def run(args=sys.argv[1:]):
     options = Options()
     try:
         options.parseOptions(args)


### PR DESCRIPTION
> *Tu quoue, argv[0], fili mi!*

Closes #457 reported by @anadahz.

Tested locally (this time!) by running:

```
export PYTHONPATH=.
./bin/oonireport status
./bin/oonireport --version
./bin/oonireport upload
```

All commands now seem to work as they should.