### PR TITLE
[hotfix] Fix parsing of command line arguments for oonireport

### DIFF
--- a/ooni/report/cli.py
+++ b/ooni/report/cli.py
@@ -60,7 +60,7 @@ def tor_check():
         sys.exit(1)
 
 
-def run(args=sys.argv):
+def run(args=None):
     options = Options()
     try:
         options.parseOptions(args)


### PR DESCRIPTION
This closes #547 