### PR TITLE
Add ooniprobe v2.0.0 install instructions, cleanup, fix URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,9 +68,6 @@ Make sure you have installed the following dependencies:
   * libpcap-dev
   * libssl-dev
   * libffi-dev
-  * libgmp-dev
-  * openssl
-  * libyaml-dev
   * tor (>=0.2.5.1 to run all the tor related tests)
 
 Optional dependencies:
@@ -79,7 +76,7 @@ Optional dependencies:
 
 On debian based systems this can generally be done by running::
 
-    sudo apt-get install -y build-essential libdumbnet-dev libpcap-dev libgeoip-dev libffi-dev python-dev python-pip tor libgmp-dev obfs4proxy
+    sudo apt-get install -y build-essential libdumbnet-dev libpcap-dev libgeoip-dev libffi-dev python-dev python-pip tor libssl-dev obfs4proxy
 
 Then you should be able to install ooniprobe by running::
 
@@ -158,12 +155,12 @@ responsible for the tasks scheduling.
 You can ensure that ooniprobe-agent is always running by installing and enabling
 the systemd unit `ooniprobe.service`::
 
-    git clone https://github.com/TheTorProject/ooni-probe.git
-    cp ooni-probe/scripts/systemd/ooniprobe.service $(pkg-config systemd --variable=systemdsystemconfdir)
+    wget https://raw.githubusercontent.com/TheTorProject/ooni-probe/master/scripts/systemd/ooniprobe.service --directory-prefix=/etc/systemd/system
     systemctl enable ooniprobe
     systemctl start ooniprobe
 
-You should be able to see something similar if ooniprobe service is running::
+You should be able to see a similar output if ooniprobe (systemd) service is
+active and loaded by running `systemctl status ooniprobe`::
 
     ● ooniprobe.service - ooniprobe.service, network interference detection tool
        Loaded: loaded (/etc/systemd/system/ooniprobe.service; enabled)

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,50 @@ Furthermore, ooniprobe takes no precautions to protect the install target machin
 from forensics analysis.  If the fact that you have installed or used ooni
 probe is a liability for you, please be aware of this risk.
 
+OONI in 5 minutes
+=================
+
+The latest ooniprobe version for Debian and Ubuntu releases can be found in the
+deb.torproject.org package repository.
+
+On Debian stable (jessie)::
+
+    gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+    echo 'deb http://deb.torproject.org/torproject.org jessie main' | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+    sudo apt-get update
+    sudo apt-get install ooniprobe deb.torproject.org-keyring
+
+On Debian testing::
+
+    gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+    echo 'deb http://deb.torproject.org/torproject.org testing main' | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+    sudo apt-get update
+    sudo apt-get install ooniprobe deb.torproject.org-keyring
+
+On Debian unstable::
+
+    gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+    echo 'deb http://deb.torproject.org/torproject.org unstable main' | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+    sudo apt-get update
+    sudo apt-get install ooniprobe deb.torproject.org-keyring
+
+On Ubuntu 16.10 (yakkety), 16.04 (xenial), 15.10 (wily) or 14.04 (trusty)::
+
+    gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+    echo 'deb http://deb.torproject.org/torproject.org $RELEASE main' | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+    sudo apt-get update
+    sudo apt-get install ooniprobe deb.torproject.org-keyring
+
+Note: You'll need to swap out ``$RELEASE`` for either ``yakkety``, ``xenial``,
+``wily``, or ``trusty``. This will not happen automatically. You will also need
+to ensure that you have the ``universe`` repository enabled. The ``universe``
+repository is enabled by default in a standard Ubuntu installation but may not
+be on some minimal on not standard installations.
+
 Installation
 ============
 
@@ -110,13 +154,13 @@ On debian/ubuntu::
 
 4. Login to the box with::
 
-    vagrant ssh
+    vagrant ssh probe
 
 5. Start ooniprobe agent::
 
     ooniprobe-agent start
 
-6. Connect to the web UI on your host machine at http://localhost:8042/
+6. Connect to the web UI on your host machine at http://localhost:8842/
 
 
 Using ooniprobe
@@ -136,7 +180,7 @@ Configuring ooniprobe
 ---------------------
 
 After successfully installing ooniprobe you should be able to access the web UI
-on your host machine at http://localhost:8042/ .
+on your host machine at http://localhost:8842/ .
 
 You should now be presented with the web UI setup wizard where you can read the
 risks involved with running ooniprobe. Upon answering the quiz correctly you can

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ On Debian unstable::
     sudo apt-get update
     sudo apt-get install ooniprobe deb.torproject.org-keyring
 
-On Ubuntu 16.10 (yakkety), 16.04 (xenial), 15.10 (wily) or 14.04 (trusty)::
+On Ubuntu 16.10 (yakkety), 16.04 (xenial) or 14.04 (trusty)::
 
     gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
     gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
@@ -82,11 +82,11 @@ On Ubuntu 16.10 (yakkety), 16.04 (xenial), 15.10 (wily) or 14.04 (trusty)::
     sudo apt-get update
     sudo apt-get install ooniprobe deb.torproject.org-keyring
 
-Note: You'll need to swap out ``$RELEASE`` for either ``yakkety``, ``xenial``,
-``wily``, or ``trusty``. This will not happen automatically. You will also need
-to ensure that you have the ``universe`` repository enabled. The ``universe``
-repository is enabled by default in a standard Ubuntu installation but may not
-be on some minimal on not standard installations.
+Note: You'll need to swap out ``$RELEASE`` for either ``yakkety``, ``xenial`` or
+``trusty``. This will not happen automatically. You will also need to ensure
+that you have the ``universe`` repository enabled. The ``universe`` repository
+is enabled by default in a standard Ubuntu installation but may not be on some
+minimal on not standard installations.
 
 Installation
 ============


### PR DESCRIPTION
- Add installation instructions for ooniprobe v2.0.0
- Update git repository URLs
- Cleanup obsolete old documentation
