### PR TITLE
Bump version number to be used in master

### DIFF
--- a/ooni/__init__.py
+++ b/ooni/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 __author__ = "Open Observatory of Network Interference"
-__version__ = "2.0.0"
+__version__ = "2.0.1.dev0"
 
 __all__ = [
     'agent',


### PR DESCRIPTION
The version number of master should always be `.dev`