### PR TITLE
remove references to ooniresources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,18 +186,6 @@ By default ooniprobe will not include personal identifying information in the
 test result, nor create a pcap file. This behavior can be personalized.
 
 
-Updating resources
-------------------
-
-To generate decks you will have to update the input resources of ooniprobe.
-
-This can be done with::
-
-    ooniresources
-
-If you get a permission error, you may have to run the command as root or
-change the ooniprobe data directory inside of `ooniprobe.conf`.
-
 Generating decks
 ----------------
 


### PR DESCRIPTION
Still some more references to `ooniresources`:

```
(.env)l@tp ~/code/Tor/ooni-probe [remove-ooniresources] $ ack ooniresources
ChangeLog.rst
223:* Fix bug that lead to ooniresources not working properly

data/ooniresources.1
5:ooniresources \- DEPRECATED ooni tool
35:\fBooniresources\fP
38:\fBooniresources\fP, has now been superseded by a system that

setup.py
269:                'ooniresources = ooni.scripts.ooniresources:run',  # This is deprecated

docs/source/manual/ooniresources.rst
1:ooniresources - DEPRECATED
7:**ooniresources**
12::program:`ooniresources`, has now been superseded by a system that

docs/source/index.rst
74:    sudo ooniresources --update-inputs --update-geoip
199:    ooniresources --update-inputs
206:with ``ooniresources``::
208:    ooniresources --update-geoip

docs/source/conf.py
225:    ('manual/ooniresources', 'ooniresources', u'DEPRECATED ooni tool', [u'The Tor Project'], 1),

ooni/scripts/ooniresources.py
21:        print("ooniresources version: %s" % __version__)

ooni/geoip.py
45:                "Try running ooniresources or"

MANIFEST.in
8:include data/ooniresources.1
```

And things like "(be sure to have updated the input resources first)"