### PR TITLE
Feature/deck status

### DIFF
--- a/ooni/agent/scheduler.py
+++ b/ooni/agent/scheduler.py
@@ -294,7 +294,7 @@ class RunDeck(ScheduledTask):
     def task(self):
         deck = deck_store.get(self.deck_id)
         yield deck.setup()
-        yield deck.run(self.director)
+        yield deck.run(self.director, from_schedule=True)
 
 
 class RefreshDeckList(ScheduledTask):

--- a/ooni/deck/deck.py
+++ b/ooni/deck/deck.py
@@ -234,7 +234,7 @@ class NGDeck(object):
         # XXX-REFACTOR we do this so late to avoid the collision between the
         #  same id and hence generating the same filename.
         test_details = net_test_loader.getTestDetails()
-        task.id = generate_filename(test_details)
+        task.id = generate_filename(test_details, deck_id=self.id)
 
         measurement_id = None
         report_filename = task.output_path
@@ -330,7 +330,8 @@ class DeckTask(object):
 
         self.ooni = {
             'bouncer_client': None,
-            'test_details': {}
+            'test_details': {},
+            'test_name': None
         }
         self.output_path = None
 
@@ -353,8 +354,9 @@ class DeckTask(object):
             if required_key not in task_data:
                 raise MissingTaskDataKey(required_key)
 
+        self.ooni['test_name'] = task_data.pop('test_name')
         # This raises e.NetTestNotFound, we let it go onto the caller
-        nettest_path = nettest_to_path(task_data.pop("test_name"),
+        nettest_path = nettest_to_path(self.ooni['test_name'],
                                        self._arbitrary_paths)
 
         annotations = self._pop_option('annotations', task_data, {})

--- a/ooni/deck/deck.py
+++ b/ooni/deck/deck.py
@@ -1,4 +1,5 @@
 import os
+import json
 import uuid
 import errno
 import hashlib
@@ -36,14 +37,12 @@ def options_to_args(options):
     for k, v in options.items():
         if v is None:
             continue
-        if v == False or v == 0:
+        if isinstance(v, bool):
             continue
         if (len(k)) == 1:
             args.append('-'+k)
         else:
             args.append('--'+k)
-        if isinstance(v, bool) or isinstance(v, int):
-            continue
         args.append(v)
     return args
 
@@ -112,7 +111,7 @@ class NGDeck(object):
         if self.id is None:
             # This happens when you load a deck not from a filepath so we
             # use the first 16 characters of the SHA256 hexdigest as an ID
-            self.id = hashlib.sha256(deck_data).hexdigest()[:16]
+            self.id = hashlib.sha256(json.dumps(deck_data)).hexdigest()[:16]
         if global_options is not None:
             self.global_options = normalize_options(global_options)
 

--- a/ooni/deck/deck.py
+++ b/ooni/deck/deck.py
@@ -37,12 +37,14 @@ def options_to_args(options):
     for k, v in options.items():
         if v is None:
             continue
-        if isinstance(v, bool):
+        if v == False:
             continue
         if (len(k)) == 1:
             args.append('-'+k)
         else:
             args.append('--'+k)
+        if v == True:
+            continue
         args.append(v)
     return args
 

--- a/ooni/deck/legacy.py
+++ b/ooni/deck/legacy.py
@@ -30,7 +30,10 @@ boolean_options = [
     'no-collector',
     'no-geoip',
     'no-yamloo',
-    'verbose'
+    'verbose',
+    'help',
+    'no-default-reporter',
+    'resume'
 ]
 
 def convert_legacy_deck(deck_data):

--- a/ooni/deck/legacy.py
+++ b/ooni/deck/legacy.py
@@ -26,6 +26,13 @@ def subargs_to_options(subargs):
 
     return options
 
+boolean_options = [
+    'no-collector',
+    'no-geoip',
+    'no-yamloo',
+    'verbose'
+]
+
 def convert_legacy_deck(deck_data):
     """
     I take a legacy deck list and convert it to the new deck format.
@@ -58,6 +65,8 @@ def convert_legacy_deck(deck_data):
             deck_task["ooni"][name] = value
 
         for name, value in options.items():
+            if name in boolean_options:
+                value = False if value == 0 else True
             deck_task["ooni"][name] = value
 
         new_deck_data["tasks"].append(deck_task)

--- a/ooni/deck/store.py
+++ b/ooni/deck/store.py
@@ -227,11 +227,10 @@ class DeckStore(object):
         for deck_path in self.available_directory.listdir():
             if not deck_path.endswith('.yaml'):
                 continue
-            deck_id = deck_path[:-1*len('.yaml')]
             deck = NGDeck(
                 deck_path=self.available_directory.child(deck_path).path
             )
-            new_cache[deck_id] = deck
+            new_cache[deck.id] = deck
         self._cache = new_cache
         self._cache_stale = False
 

--- a/ooni/director.py
+++ b/ooni/director.py
@@ -70,6 +70,7 @@ class Director(object):
 
     def __init__(self):
         self.activeNetTests = []
+        self.activeDecks = []
 
         self.measurementManager = MeasurementManager()
         self.measurementManager.director = self
@@ -289,6 +290,32 @@ class Director(object):
         self.failedMeasurements += 1
         measurement.result = failure
         return measurement
+
+    def deckStarted(self, deck_id, from_schedule):
+        log.debug("Starting {0} ({1})".format(deck_id,
+                                              'scheduled' if from_schedule
+                                              else 'user-run'))
+        self.activeDecks.append((deck_id, from_schedule))
+
+    def deckFinished(self, deck_id, from_schedule):
+        log.debug("Finished {0} ({1})".format(deck_id,
+                                              'scheduled' if from_schedule
+                                              else 'user-run'))
+        try:
+            self.activeDecks.remove((deck_id, from_schedule))
+        except ValueError:
+            log.error("Completed deck {0} is not actually running".format(
+                deck_id))
+
+
+    def isDeckRunning(self, deck_id, from_schedule):
+        """
+        :param deck_id: the ID of the deck to check if it's running
+        :param from_schedule:  True if we want to know the status of a
+        scheduled deck run False for user initiated runs.
+        :return: True if the deck is running False otherwise
+        """
+        return (deck_id, from_schedule) in self.activeDecks
 
     def netTestDone(self, net_test):
         self.notify(DirectorEvent("success",

--- a/ooni/measurements.py
+++ b/ooni/measurements.py
@@ -93,11 +93,14 @@ def get_measurement(measurement_id, compute_size=False):
     stale = False
     if measurement.child("measurements.njson.progress").exists():
         completed = False
-        pid = measurement.child("running.pid").open("r").read()
-        pid = int(pid)
-        if is_process_running(pid):
-            running = True
-        else:
+        try:
+            pid = measurement.child("running.pid").open("r").read()
+            pid = int(pid)
+            if is_process_running(pid):
+                running = True
+            else:
+                stale = True
+        except IOError:
             stale = True
 
     if measurement.child("keep").exists():

--- a/ooni/measurements.py
+++ b/ooni/measurements.py
@@ -11,7 +11,7 @@ from ooni.settings import config
 class MeasurementInProgress(Exception):
     pass
 
-class Process():
+class MeasurementTypes():
     supported_tests = [
         "web_connectivity",
         "http_requests",
@@ -51,14 +51,15 @@ class Process():
         result['url'] = entry['input']
         return result
 
-def generate_summary(input_file, output_file):
+
+def generate_summary(input_file, output_file, deck_id='none'):
     results = {}
     with open(input_file) as in_file:
         for idx, line in enumerate(in_file):
             entry = json.loads(line.strip())
             result = {}
-            if entry['test_name'] in Process.supported_tests:
-                result = getattr(Process, entry['test_name'])(entry)
+            if entry['test_name'] in MeasurementTypes.supported_tests:
+                result = getattr(MeasurementTypes, entry['test_name'])(entry)
             result['idx'] = idx
             if not result.get('url', None):
                 result['url'] = entry['input']
@@ -66,6 +67,7 @@ def generate_summary(input_file, output_file):
             results['test_start_time'] = entry['test_start_time']
             results['country_code'] = entry['probe_cc']
             results['asn'] = entry['probe_asn']
+            results['deck_id'] = deck_id
             results['results'] = results.get('results', [])
             results['results'].append(result)
 
@@ -73,8 +75,10 @@ def generate_summary(input_file, output_file):
         json.dump(results, fw)
     return results
 
+
 class MeasurementNotFound(Exception):
     pass
+
 
 def get_measurement(measurement_id, compute_size=False):
     size = -1
@@ -114,7 +118,9 @@ def get_measurement(measurement_id, compute_size=False):
         "keep": keep,
         "running": running,
         "stale": stale,
-        "size": size
+        "size": size,
+        # XXX we need the deck ID in here
+        "deck_id": "none"
     }
 
 

--- a/ooni/measurements.py
+++ b/ooni/measurements.py
@@ -106,8 +106,11 @@ def get_measurement(measurement_id, compute_size=False):
     if compute_size is True:
         size = directory_usage(measurement.path)
 
-    test_start_time, country_code, asn, test_name = \
-        measurement_id.split("-")[:4]
+    measurement_metadata = measurement_id.split("-")
+    test_start_time, country_code, asn, test_name = measurement_metadata[:4]
+    deck_id = "none"
+    if len(measurement_metadata) > 4:
+        deck_id = '-'.join(measurement_metadata[4:])
     return {
         "test_name": test_name,
         "country_code": country_code,
@@ -119,8 +122,7 @@ def get_measurement(measurement_id, compute_size=False):
         "running": running,
         "stale": stale,
         "size": size,
-        # XXX we need the deck ID in here
-        "deck_id": "none"
+        "deck_id": deck_id
     }
 
 
@@ -156,8 +158,9 @@ def list_measurements(compute_size=False, order=None):
     for measurement_id in measurement_path.listdir():
         try:
             measurements.append(get_measurement(measurement_id, compute_size))
-        except:
+        except Exception as exc:
             log.err("Failed to get metadata for measurement {0}".format(measurement_id))
+            log.exception(exc)
 
     if order is None:
         return measurements

--- a/ooni/tests/test_deck.py
+++ b/ooni/tests/test_deck.py
@@ -336,5 +336,7 @@ class TestNGDeck(ConfigTestCase):
             '/path/to/citizenlab-urls-global.txt')
 
     def test_options_to_args(self):
-        args = options_to_args({"f": "foobar.txt", "bar": None, "help": 0})
-        print(args)
+        args = options_to_args({"f": "foobar.txt", "bar": None,
+                                "disabled-flag": False, "enabled-flag": True})
+        self.assertEqual(set(args), set(['-f', 'foobar.txt',
+                                         '--enabled-flag']))

--- a/ooni/tests/test_scheduler.py
+++ b/ooni/tests/test_scheduler.py
@@ -312,7 +312,7 @@ class TestSchedulerService(ConfigTestCase):
 
             # We check that the run method of the deck was called twice
             self.mock_deck.run.assert_has_calls([
-                mock.call(mock_director), mock.call(mock_director)
+                mock.call(mock_director, from_schedule=True), mock.call(mock_director, from_schedule=True)
             ])
             d.callback(None)
 

--- a/ooni/ui/cli.py
+++ b/ooni/ui/cli.py
@@ -377,7 +377,7 @@ def runTestWithDirector(director, global_options, url=None,
     def post_director_start(_):
         try:
             yield deck.setup()
-            yield deck.run(director)
+            yield deck.run(director, from_schedule=False)
         except errors.UnableToLoadDeckInput as error:
             raise defer.failure.Failure(error)
         except errors.NoReachableTestHelpers as error:

--- a/ooni/ui/web/server.py
+++ b/ooni/ui/web/server.py
@@ -481,7 +481,8 @@ class WebUIAPI(object):
             raise WebUIError(
                 400, 'Insufficient privileges'
             )
-        except:
+        except Exception as exc:
+            log.exception(exc)
             raise WebUIError(
                 500, 'Failed to start nettest'
             )

--- a/ooni/ui/web/server.py
+++ b/ooni/ui/web/server.py
@@ -370,6 +370,12 @@ class WebUIAPI(object):
     def api_deck_list(self, request):
         deck_list = {'decks': []}
         for deck_id, deck in self.director.deck_store.list():
+            nettests = []
+            for task in deck.tasks:
+                if task.type == 'ooni':
+                    assert task.ooni['test_name'] is not None
+                    nettests.append(task.ooni['test_name'])
+
             deck_list['decks'].append({
                 'id': deck_id,
                 'name': deck.name,
@@ -378,7 +384,7 @@ class WebUIAPI(object):
                                             deck_id, from_schedule=False),
                 'running_scheduled': self.director.isDeckRunning(
                                             deck_id, from_schedule=True),
-                'nettests': [], #XXX
+                'nettests': nettests,
                 'description': deck.description,
                 'schedule': deck.schedule,
                 'enabled': self.director.deck_store.is_enabled(deck_id)

--- a/ooni/ui/web/server.py
+++ b/ooni/ui/web/server.py
@@ -147,7 +147,7 @@ class WebUIAPI(object):
     app = Klein()
     # Maximum number in seconds after which to return a result even if no
     # change happened.
-    _long_polling_timeout = 5
+    _long_polling_timeout = 30
     _reactor = reactor
     _enable_xsrf_protection = True
 
@@ -171,8 +171,8 @@ class WebUIAPI(object):
         # We use exponential backoff to trigger retries of the startup of
         # the director.
         self._director_startup_retries = 0
-        # Maximum delay should be 6 hours
-        self._director_max_retry_delay = 6*60*60
+        # Maximum delay should be 30 minutes
+        self._director_max_retry_delay = 30*60
 
         self.status_poller = LongPoller(
             self._long_polling_timeout, _reactor)
@@ -368,26 +368,21 @@ class WebUIAPI(object):
     @xsrf_protect(check=False)
     @requires_true(attrs=['_director_started', '_is_initialized'])
     def api_deck_list(self, request):
-        deck_list = {
-            'available': {},
-            'enabled': {}
-        }
+        deck_list = {'decks': []}
         for deck_id, deck in self.director.deck_store.list():
-            deck_list['available'][deck_id] = {
+            deck_list['decks'].append({
+                'id': deck_id,
                 'name': deck.name,
+                'icon': deck.icon,
+                'running': self.director.isDeckRunning(
+                                            deck_id, from_schedule=False),
+                'running_scheduled': self.director.isDeckRunning(
+                                            deck_id, from_schedule=True),
+                'nettests': [], #XXX
                 'description': deck.description,
                 'schedule': deck.schedule,
                 'enabled': self.director.deck_store.is_enabled(deck_id)
-            }
-
-        for deck_id, deck in self.director.deck_store.list_enabled():
-            deck_list['enabled'][deck_id] = {
-                'name': deck.name,
-                'description': deck.description,
-                'schedule': deck.schedule,
-                'enabled': True
-            }
-
+            })
         return self.render_json(deck_list, request)
 
     @app.route('/api/deck/<string:deck_id>/run', methods=["POST"])
@@ -433,9 +428,12 @@ class WebUIAPI(object):
         # These are dangling deferreds
         try:
             yield deck.setup()
-            yield deck.run(self.director)
+            yield deck.run(self.director, from_schedule=False)
+            self.director_event_poller.notify(DirectorEvent("success",
+                                                            "Started Deck "
+                                                            + deck.id))
         except:
-            self.director_event_poller.notify(DirectorEvent("error",
+             self.director_event_poller.notify(DirectorEvent("error",
                                                             "Failed to start deck"))
 
     @app.route('/api/nettest/<string:test_name>/start', methods=["POST"])

--- a/ooni/utils/__init__.py
+++ b/ooni/utils/__init__.py
@@ -1,7 +1,6 @@
 import shutil
 import string
 import random
-import signal
 import errno
 import gzip
 import os
@@ -103,7 +102,7 @@ def randomDate(start, end):
 LONG_DATE = "%Y-%m-%d %H:%M:%S"
 SHORT_DATE = "%Y%m%dT%H%M%SZ"
 
-def generate_filename(test_details, prefix=None, extension=None):
+def generate_filename(test_details, prefix=None, extension=None, deck_id=None):
     """
     Returns a filename for every test execution.
 
@@ -116,6 +115,9 @@ def generate_filename(test_details, prefix=None, extension=None):
         kwargs["prefix"] = prefix
         filename_format += "{prefix}-"
     filename_format += "{timestamp}-{probe_cc}-{probe_asn}-{test_name}"
+    if deck_id is not None:
+        kwargs["deck_id"] = deck_id
+        filename_format += "-{deck_id}"
     if extension is not None:
         kwargs["extension"] = extension
         filename_format += ".{extension}"


### PR DESCRIPTION
This branch adds support for the following features:

* We should keep track of the running or not running status of a deck #706
* Adjust the /api/deck endpoint #704
* The /api/deck endpoint should return the list of tests in a deck #705
* Measurements should include details of which deck generated them #707
