### PR TITLE
support unix-socket tor control ports #479

### DIFF
--- a/data/ooniprobe.conf.sample
+++ b/data/ooniprobe.conf.sample
@@ -67,6 +67,9 @@ advanced:
 tor:
     #socks_port: 8801
     #control_port: 8802
+    # Alternatively set control_port to the unix domain socket. Useful for Debian based systems
+    #control_port: unix:/var/run/tor/control
+    #
     # Specify the absolute path to the Tor bridges to use for testing
     #bridges: bridges.list
     # Specify path of the tor datadirectory.

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -538,6 +538,6 @@ class OConfig(object):
                 else:
 			incoherent.append('tor:control_port')
 
-       self.log_incoherences(incoherent)
+        self.log_incoherences(incoherent)
 
 config = OConfig()

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -519,24 +519,24 @@ class OConfig(object):
                 except Exception:
                     incoherent.append('tor:socks_port')
 
-	    if self.tor.control_port is not None:
-       	        if isinstance(self.tor.control_port, int):
-	            control_port_ep = TCP4ClientEndpoint(reactor,
+            if self.tor.control_port is not None:
+                if isinstance(self.tor.control_port, int):
+                    control_port_ep = TCP4ClientEndpoint(reactor,
                                                          "localhost",
                                                          self.tor.control_port)
-		    try:
-		        yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
-		    except Exception:
-		        incoherent.append('tor:control_port')		
+                    try:
+                        yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
+                    except Exception:
+                        incoherent.append('tor:control_port')
                 else:
-		    conf_unix_socket_path = self.tor.control_port
-		    if conf_unix_socket_path.lstrip.startswith("unix:"):
-	                if os.path.exists(conf_unix_socket_path.lstrip("unix:")):
-			    unix_socket_path = conf_unix_socket_path.lstrip("unix:")
-			else:
-		 	    incoherent.append('tor:control_port')
+                    conf_unix_socket_path = self.tor.control_port
+                    if conf_unix_socket_path.lstrip.startswith("unix:"):
+                        if os.path.exists(conf_unix_socket_path.lstrip("unix:")):
+                            unix_socket_path = conf_unix_socket_path.lstrip("unix:")
+                        else:
+                            incoherent.append('tor:control_port')
                     else:
-		        incoherent.append('tor:control_port')
+                        incoherent.append('tor:control_port')
 
             self.log_incoherences(incoherent)
 

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -529,10 +529,15 @@ class OConfig(object):
 		except Exception:
 		    incoherent.append('tor:control_port')		
             else:
-		if self.tor.control_port.lstrip.startswith("unix:"):
-		    control_port_ep = self.tor.control_port.lstrip("unix:")
-               	           
+		conf_unix_socket_path = self.tor.control_port
+		if conf_unix_socket_path.lstrip.startswith("unix:"):
+			if os.path.exists(conf_unix_socket_path.lstrip("unix:")):
+				unix_socket_path = conf_unix_socket_path.lstrip("unix:")
+			else:
+				incoherent.append('tor:control_port')
+                else:
+			incoherent.append('tor:control_port')
 
-            self.log_incoherences(incoherent)
+       self.log_incoherences(incoherent)
 
 config = OConfig()

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -520,7 +520,7 @@ class OConfig(object):
                     incoherent.append('tor:socks_port')
 
 	if self.tor.control_port is not None:
-       	    if isinstance(self.tor.control_port,int):
+       	    if isinstance(self.tor.control_port, int):
 	        control_port_ep = TCP4ClientEndpoint(reactor,
                                                      "localhost",
                                                      self.tor.control_port)

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -519,25 +519,25 @@ class OConfig(object):
                 except Exception:
                     incoherent.append('tor:socks_port')
 
-	if self.tor.control_port is not None:
-       	    if isinstance(self.tor.control_port, int):
-	        control_port_ep = TCP4ClientEndpoint(reactor,
-                                                     "localhost",
-                                                     self.tor.control_port)
-		try:
-		    yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
-		except Exception:
-		    incoherent.append('tor:control_port')		
-            else:
-		conf_unix_socket_path = self.tor.control_port
-		if conf_unix_socket_path.lstrip.startswith("unix:"):
-			if os.path.exists(conf_unix_socket_path.lstrip("unix:")):
-				unix_socket_path = conf_unix_socket_path.lstrip("unix:")
-			else:
-				incoherent.append('tor:control_port')
+	    if self.tor.control_port is not None:
+       	        if isinstance(self.tor.control_port, int):
+	            control_port_ep = TCP4ClientEndpoint(reactor,
+                                                         "localhost",
+                                                         self.tor.control_port)
+		    try:
+		        yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
+		    except Exception:
+		        incoherent.append('tor:control_port')		
                 else:
-			incoherent.append('tor:control_port')
+		    conf_unix_socket_path = self.tor.control_port
+		    if conf_unix_socket_path.lstrip.startswith("unix:"):
+	                if os.path.exists(conf_unix_socket_path.lstrip("unix:")):
+			    unix_socket_path = conf_unix_socket_path.lstrip("unix:")
+			else:
+		 	    incoherent.append('tor:control_port')
+                    else:
+		        incoherent.append('tor:control_port')
 
-        self.log_incoherences(incoherent)
+            self.log_incoherences(incoherent)
 
 config = OConfig()

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -85,6 +85,9 @@ advanced:
 tor:
     #socks_port: 8801
     #control_port: 8802
+    # Alternatively set control_port to the unix domain socket. Useful for Debian based systems
+    #control_port: unix:/var/run/tor/control
+    #
     # Specify the absolute path to the Tor bridges to use for testing
     #bridges: bridges.list
     # Specify path of the tor datadirectory.

--- a/ooni/settings.py
+++ b/ooni/settings.py
@@ -519,14 +519,19 @@ class OConfig(object):
                 except Exception:
                     incoherent.append('tor:socks_port')
 
-            if self.tor.control_port is not None:
-                control_port_ep = TCP4ClientEndpoint(reactor,
+	if self.tor.control_port is not None:
+       	    if isinstance(self.tor.control_port,int):
+	        control_port_ep = TCP4ClientEndpoint(reactor,
                                                      "localhost",
                                                      self.tor.control_port)
-                try:
-                    yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
-                except Exception:
-                    incoherent.append('tor:control_port')
+		try:
+		    yield connectProtocol(control_port_ep, ConnectAndCloseProtocol())
+		except Exception:
+		    incoherent.append('tor:control_port')		
+            else:
+		if self.tor.control_port.lstrip.startswith("unix:"):
+		    control_port_ep = self.tor.control_port.lstrip("unix:")
+               	           
 
             self.log_incoherences(incoherent)
 

--- a/ooni/ui/cli.py
+++ b/ooni/ui/cli.py
@@ -26,7 +26,7 @@ class Options(usage.Options):
     optFlags = [["help", "h"],
                 ["no-collector", "n", "Disable writing to collector"],
                 ["no-njson", "N", "Disable writing to disk"],
-                ["no-geoip", "g", "Disable geoip lookup on start."
+                ["no-geoip", "g", "Disable geoip lookup on start. "
                                   "With this option your IP address can be disclosed in the report."],
                 ["list", "s", "List the currently installed ooniprobe "
                               "nettests"],


### PR DESCRIPTION
According to the Issue #479 a small number of changes have been performed in the files:
- data/ooniprobe.conf.sample
- ooni/settings.py