### PR TITLE
Fix bug in handling of request headers

### DIFF
--- a/ooni/common/txextra.py
+++ b/ooni/common/txextra.py
@@ -37,6 +37,12 @@ class TrueHeaders(Headers):
         self._rawHeaders[name.lower()]['name'] = name
         self._rawHeaders[name.lower()]['values'] = values
 
+    def copy(self):
+        rawHeaders = {}
+        for k, v in self.getAllRawHeaders():
+            rawHeaders[k] = v
+        return self.__class__(rawHeaders)
+
     def getAllRawHeaders(self):
         for _, v in self._rawHeaders.iteritems():
             yield v['name'], v['values']
@@ -197,7 +203,11 @@ class FixedRedirectAgent(BrowserLikeRedirectAgent):
             response.request.absoluteURI,
             locationHeaders[0]
         )
-        uri = client.URI.fromBytes(location)
+        if getattr(client, 'URI', None):
+            uri = client.URI.fromBytes(location)
+        else:
+            # Backward compatibility with twisted 14.0.2
+            uri = client._URI.fromBytes(location)
         if self.ignorePrivateRedirects and is_private_address(uri.host,
                                                               only_loopback=True):
             return response

--- a/ooni/tests/test_common.py
+++ b/ooni/tests/test_common.py
@@ -41,7 +41,7 @@ class TestTxExtra(unittest.TestCase):
     @defer.inlineCallbacks
     def test_redirect_works(self):
         agent = FixedRedirectAgent(TrueHeadersAgent(reactor))
-        headers = TrueHeaders({"Spam": "ham"})
+        headers = TrueHeaders({"Spam": ["ham"]})
         url = "http://httpbin.org/absolute-redirect/3"
         response = yield agent.request('GET', url, headers)
         body = yield readBody(response)

--- a/ooni/tests/test_common.py
+++ b/ooni/tests/test_common.py
@@ -3,6 +3,8 @@ from twisted.trial import unittest
 from twisted.internet import defer, reactor
 from twisted.web.client import readBody
 
+from . import is_internet_connected
+
 from ooni.common.http_utils import META_CHARSET_REGEXP
 from ooni.common.ip_utils import is_public_ipv4_address, is_private_ipv4_address
 from ooni.common.txextra import FixedRedirectAgent, TrueHeadersAgent, TrueHeaders
@@ -40,6 +42,9 @@ class TestIPUtils(unittest.TestCase):
 class TestTxExtra(unittest.TestCase):
     @defer.inlineCallbacks
     def test_redirect_works(self):
+        if not is_internet_connected():
+            raise unittest.SkipTest("Internet connection missing")
+
         agent = FixedRedirectAgent(TrueHeadersAgent(reactor))
         headers = TrueHeaders({"Spam": ["ham"]})
         url = "http://httpbin.org/absolute-redirect/3"


### PR DESCRIPTION
This bug is the reason why when we hit a redirect measurements are inconsistent.

Basically we were not passing along the headers when handling a redirect.

Weirdly enough the bug is due to us not properly implementing the `copy` method inside of our custom `TrueHeaders` class.