### PR TITLE
Fix Microsoft Azure meek endpoint, format

### DIFF
--- a/ooni/nettests/blocking/meek_fronted_requests.py
+++ b/ooni/nettests/blocking/meek_fronted_requests.py
@@ -8,12 +8,12 @@ from ooni.utils import log
 
 class UsageOptions(usage.Options):
     optParameters = [ ['expectedBody', 'B',
-                         'I’m just a happy little web server.\n',
-                          'Expected body content from GET response.'],
+                       'I’m just a happy little web server.\n',
+                       'Expected body content from GET response.'],
                       ['domainName', 'D', None,
-                        'Specify a single fronted domainName to test.'],
+                       'Specify a single fronted domainName to test.'],
                       ['hostHeader', 'H', None,
-                        'Specify "inside" Host Header to test.']
+                       'Specify "inside" Host Header to test.']
                     ]
 
 class meekTest(httpt.HTTPTest):
@@ -23,21 +23,21 @@ class meekTest(httpt.HTTPTest):
     and response with: "I’m just a happy little web server.\n".
     The input file should be formatted as (one per line):
     "domainName:hostHeader"
-    ajax.aspnetcdn.com:az668014.vo.msecnd.net
+    ajax.aspnetcdn.com:meek.azureedge.net
     a0.awsstatic.com:d2zfqthxsdq309.cloudfront.net
 
     """
     name = "Meek fronted requests test"
     description = "This test examines whether the domains used by Meek "\
                   "(a type of Tor bridge) work in your network."
-    version = "0.1.0"
+    version = "0.2.0"
 
     usageOptions = UsageOptions
     inputFile = ['file', 'f', None,
-                  "File containing the domainName:hostHeader combinations to\
-                  be tested, one per line."]
-    inputs = [('ajax.aspnetcdn.com', 'az668014.vo.msecnd.net'),
-               ('a0.awsstatic.com', 'd2zfqthxsdq309.cloudfront.net')]
+                 'File containing the domainName:hostHeader combinations to \
+                  be tested, one per line.']
+    inputs = [('ajax.aspnetcdn.com', 'meek.azureedge.net'),
+              ('a0.awsstatic.com', 'd2zfqthxsdq309.cloudfront.net')]
 
     requiresRoot = False
     requiresTor = False
@@ -76,4 +76,3 @@ class meekTest(httpt.HTTPTest):
         headers['Host'] = [self.header]
         return self.doRequest(self.domainName, method="GET", headers=headers,
                               body_processor=process_body)
-

--- a/ooni/nettests/blocking/meek_fronted_requests.py
+++ b/ooni/nettests/blocking/meek_fronted_requests.py
@@ -37,7 +37,7 @@ class meekTest(httpt.HTTPTest):
                  'File containing the domainName:hostHeader combinations to \
                   be tested, one per line.']
     inputs = [('ajax.aspnetcdn.com', 'meek.azureedge.net'),
-              ('a0.awsstatic.com', 'd2zfqthxsdq309.cloudfront.net')]
+              ('a0.awsstatic.com', 'd2cly7j4zqgua7.cloudfront.net')]
 
     requiresRoot = False
     requiresTor = False


### PR DESCRIPTION
The default azure meek endpoint was [changed some months ago](https://gitweb.torproject.org/builders/tor-browser-bundle.git/commit/Bundle-Data/PTConfigs/bridge_prefs.js?id=92c82fb6b5aa06c9ed4c304d47aca1bf3e92d1ca).

Due to the meek azure endpoint change the reports of the `meek_fronted_requests` test are reporting  a lot of false positives. An example of a `meek_fronted_requests` [test false positive report](https://explorer.ooni.torproject.org/measurement/20170328T004744Z_AS209_zG9K5kcKg3GAv7auTTuUsNWIv03OH1vje8NhvSf8I7Gzc7Ga7S?input=%5Bu%27ajax.aspnetcdn.com%27,%20u%27az668014.vo.msecnd.net%27%5D)