### PR TITLE
Randomise URLs when testing web_connectivity

### DIFF
--- a/ooni/__init__.py
+++ b/ooni/__init__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 __author__ = "Open Observatory of Network Interference"
-__version__ = "2.2.0"
+__version__ = "2.2.1-dev"
 
 __all__ = [
     'agent',

--- a/ooni/nettest.py
+++ b/ooni/nettest.py
@@ -575,8 +575,8 @@ class NetTest(object):
         log.msg("")
         log.msg("Status")
         log.msg("------")
-        log.msg("%d completed %d remaining" % (self._completedInputs,
-                                               self._totalInputs))
+        log.msg("%d/%d completed" % (self._completedInputs,
+                                     self._totalInputs))
         log.msg("%0.1f%% (ETA: %ds)" % (self.completionPercentage * 100,
                                         self.completionEta))
         self.state.taskDone()

--- a/ooni/nettests/blocking/web_connectivity.py
+++ b/ooni/nettests/blocking/web_connectivity.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import csv
+import random
 from urlparse import urlparse
 
 from twisted.internet import defer
@@ -35,6 +36,9 @@ class UsageOptions(usage.Options):
         ['backend', 'b', None, 'The web_consistency backend test helper'],
         ['retries', 'r', 1, 'Number of retries for the HTTP request'],
         ['timeout', 't', 240, 'Total timeout for this test'],
+    ]
+    optFlags = [
+        ['no-shuffle', '', 'Disable shuffling of URLs'],
     ]
 
 
@@ -123,6 +127,11 @@ class WebConnectivityTest(httpt.HTTPTest, dnst.DNSTest):
             else:
                 fh.seek(0)
                 generator = simple_file_generator(fh)
+            if self.localOptions['no-shuffle'] != True:
+                input_list = list(generator)
+                random.shuffle(input_list)
+                generator = input_list
+
             for i in generator:
                 if (not i.startswith("http://") and
                         not i.startswith("https://")):


### PR DESCRIPTION
This is aimed at reducing fingerprintabiliy of ooniprobe
Fixes: https://github.com/TheTorProject/ooni-probe/issues/480