### PR TITLE
[ci skip] Bump copyright year in the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2016, Jacob Appelbaum, Aaron Gibson, Arturo Filastò,
+Copyright (c) 2012-2017, Jacob Appelbaum, Aaron Gibson, Arturo Filastò,
                          Isis Lovecruft, The Tor Project.
 All rights reserved.
 


### PR DESCRIPTION
Straight from the bikeshedding dept.