### PR TITLE
Temporarily disable the deploy hook for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,15 @@ script:
   - sudo rm -rf _trial_temp/
 after_success:
   - coveralls
-deploy:
-  provider: script
-  script: 'scripts/deploy.sh $HOME/.ssh/id_rsa_travis'
-  on:
-    branch: master
-    condition: "$TWISTED = Twisted"
+
+# XXX this is disabled as we haven't setup docker-machine on demo.probe.ooni.io
+#deploy:
+#  provider: script
+#  script: 'scripts/deploy.sh $HOME/.ssh/id_rsa_travis'
+#  on:
+#    branch: master
+#    condition: "$TWISTED = Twisted"
+
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This currently does not work as:

1. The keys for the demo.probe.ooni.io host have changed
2. I suspect docker-machine is not setup there anymore
3. I suspect the private key for login does not work anymore

We should at some point check that ./scripts/deploy.sh works as expected